### PR TITLE
Release v1.1.1

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -20,6 +20,7 @@ ENV LANGUAGE='en_US:en'
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 # We make four distinct layers so if there are application changes the library layers can be re-used
@@ -30,7 +31,5 @@ COPY build/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8080
 USER 185
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 ENTRYPOINT [ "/opt/jboss/container/java/run/run-java.sh" ]

--- a/src/main/docker/Dockerfile.native
+++ b/src/main/docker/Dockerfile.native
@@ -23,8 +23,8 @@ RUN microdnf install -y glibc-langpack-en gzip \
     && chmod "g+rwX" /work \
     && chown 1001:root /work
 
-# Copy the native executable - use the exact filename we know exists
-COPY --chown=1001:root build/quarkus-rest-1.0.0-runner /work/application
+# Copy the native executable - wildcard so this doesn't break on every version bump
+COPY --chown=1001:root build/*-runner /work/application
 
 EXPOSE 8080
 USER 1001

--- a/src/main/docker/docker-compose-native.yml
+++ b/src/main/docker/docker-compose-native.yml
@@ -11,17 +11,18 @@ services:
       - "8081:8080"   # Changed from 8080 to avoid conflict with JVM version
       - "9001:9000"   # Changed from 9000 to avoid conflict with JVM version
     environment:
-      DEMO_HOST: postgresql
-      DEMO_PORT: 5432
-      DEMO_DB: db_local
-      DEMO_USERNAME: postgres
-      DEMO_PASSWORD: postgres
-      DEMO_SCHEMA: sch_local
-      ENABLE_QUARKUS_MANAGEMENT: "true"
+      QUARKUS_DATASOURCE_HOST: postgresql
+      QUARKUS_DATASOURCE_PORT: 5432
+      QUARKUS_DATASOURCE_DB: db_local
+      QUARKUS_DATASOURCE_USERNAME: postgres
+      QUARKUS_DATASOURCE_PASSWORD: postgres
+      QUARKUS_DATASOURCE_SCHEMA: sch_local
+      QUARKUS_MANAGEMENT_ENABLED: "true"
       # Redis configuration
       QUARKUS_REDIS_HOSTS: redis://redis:6379
-      # MinIO configuration
-      MINIO_ENDPOINT: http://minio:9090
+      # MinIO configuration — port 9000 is MinIO's container-internal listen port
+      # (see the minio service's own healthcheck below); 9090 is only the host-side mapping.
+      MINIO_URL: http://minio:9000
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
       # Tracing configuration

--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -11,17 +11,18 @@ services:
       - "8080:8080"
       - "9000:9000"   # Management port
     environment:
-      DEMO_HOST: postgresql
-      DEMO_PORT: 5432
-      DEMO_DB: db_local
-      DEMO_USERNAME: postgres
-      DEMO_PASSWORD: postgres
-      DEMO_SCHEMA: sch_local
-      ENABLE_QUARKUS_MANAGEMENT: "true"
+      QUARKUS_DATASOURCE_HOST: postgresql
+      QUARKUS_DATASOURCE_PORT: 5432
+      QUARKUS_DATASOURCE_DB: db_local
+      QUARKUS_DATASOURCE_USERNAME: postgres
+      QUARKUS_DATASOURCE_PASSWORD: postgres
+      QUARKUS_DATASOURCE_SCHEMA: sch_local
+      QUARKUS_MANAGEMENT_ENABLED: "true"
       # Redis configuration
       QUARKUS_REDIS_HOSTS: redis://redis:6379
-      # MinIO configuration
-      MINIO_ENDPOINT: http://minio:9090
+      # MinIO configuration — port 9000 is MinIO's container-internal listen port
+      # (see the minio service's own healthcheck below); 9090 is only the host-side mapping.
+      MINIO_URL: http://minio:9000
       MINIO_ACCESS_KEY: minioadmin
       MINIO_SECRET_KEY: minioadmin
       # Tracing configuration

--- a/src/main/java/com/github/kaivu/adapter/in/rest/EntityDevicesResource.java
+++ b/src/main/java/com/github/kaivu/adapter/in/rest/EntityDevicesResource.java
@@ -33,8 +33,12 @@ import java.util.UUID;
 @Tag(name = "Entity Devices", description = "Entity Devices Resource")
 public class EntityDevicesResource {
 
+    private final EntityDeviceUseCase entityDeviceUseCase;
+
     @Inject
-    EntityDeviceUseCase entityDeviceUseCase;
+    public EntityDevicesResource(EntityDeviceUseCase entityDeviceUseCase) {
+        this.entityDeviceUseCase = entityDeviceUseCase;
+    }
 
     @POST
     @Operation(operationId = "createEntityDevice", summary = "Create a new Entity Device")

--- a/src/main/java/com/github/kaivu/application/exception/RangeNotSatisfiableException.java
+++ b/src/main/java/com/github/kaivu/application/exception/RangeNotSatisfiableException.java
@@ -1,0 +1,15 @@
+package com.github.kaivu.application.exception;
+
+import com.github.kaivu.common.exception.AppErrorEnum;
+import com.github.kaivu.common.exception.ServiceException;
+
+/**
+ * Thrown when an HTTP Range request cannot be satisfied (malformed or out-of-bounds byte range).
+ * Maps to 416 Requested Range Not Satisfiable, distinct from the generic 406 Not Acceptable.
+ */
+public class RangeNotSatisfiableException extends ServiceException {
+
+    public RangeNotSatisfiableException(AppErrorEnum error) {
+        super(error);
+    }
+}

--- a/src/main/java/com/github/kaivu/application/usecase/MediaStreamingService.java
+++ b/src/main/java/com/github/kaivu/application/usecase/MediaStreamingService.java
@@ -97,21 +97,27 @@ public class MediaStreamingService {
             return new RangeInfo(0, fileSize - 1);
         }
 
-        // Parse "bytes=start-end" format
+        // Parse "bytes=start-end" format (RFC 7233): "start-end", "start-" (to EOF), or "-suffixLength"
+        // (last N bytes) are all valid forms.
         if (rangeHeader.startsWith("bytes=")) {
             String range = rangeHeader.substring(6);
-            String[] parts = range.split("-");
 
             long startByte = 0;
             long endByte = fileSize - 1;
 
             try {
-                if (parts.length > 0 && !parts[0].isEmpty()) {
-                    startByte = Long.parseLong(parts[0]);
-                }
+                if (range.startsWith("-")) {
+                    long suffixLength = Long.parseLong(range.substring(1));
+                    startByte = Math.max(0, fileSize - suffixLength);
+                } else {
+                    String[] parts = range.split("-");
+                    if (parts.length > 0 && !parts[0].isEmpty()) {
+                        startByte = Long.parseLong(parts[0]);
+                    }
 
-                if (parts.length > 1 && !parts[1].isEmpty()) {
-                    endByte = Math.min(Long.parseLong(parts[1]), fileSize - 1);
+                    if (parts.length > 1 && !parts[1].isEmpty()) {
+                        endByte = Math.min(Long.parseLong(parts[1]), fileSize - 1);
+                    }
                 }
             } catch (NumberFormatException ex) {
                 throw rangeNotSatisfiable();

--- a/src/main/java/com/github/kaivu/application/usecase/MediaStreamingService.java
+++ b/src/main/java/com/github/kaivu/application/usecase/MediaStreamingService.java
@@ -2,6 +2,7 @@ package com.github.kaivu.application.usecase;
 
 import com.github.kaivu.adapter.in.rest.dto.vm.RangeInfo;
 import com.github.kaivu.adapter.in.rest.dto.vm.StreamingResponse;
+import com.github.kaivu.application.exception.RangeNotSatisfiableException;
 import com.github.kaivu.application.port.IMediaFileRepository;
 import com.github.kaivu.common.context.LanguageContext;
 import com.github.kaivu.common.exception.ServiceException;
@@ -104,17 +105,30 @@ public class MediaStreamingService {
             long startByte = 0;
             long endByte = fileSize - 1;
 
-            if (parts.length > 0 && !parts[0].isEmpty()) {
-                startByte = Long.parseLong(parts[0]);
+            try {
+                if (parts.length > 0 && !parts[0].isEmpty()) {
+                    startByte = Long.parseLong(parts[0]);
+                }
+
+                if (parts.length > 1 && !parts[1].isEmpty()) {
+                    endByte = Math.min(Long.parseLong(parts[1]), fileSize - 1);
+                }
+            } catch (NumberFormatException ex) {
+                throw rangeNotSatisfiable();
             }
 
-            if (parts.length > 1 && !parts[1].isEmpty()) {
-                endByte = Math.min(Long.parseLong(parts[1]), fileSize - 1);
+            if (startByte < 0 || startByte >= fileSize || startByte > endByte) {
+                throw rangeNotSatisfiable();
             }
 
             return new RangeInfo(startByte, endByte);
         }
 
         return new RangeInfo(0, fileSize - 1);
+    }
+
+    private ServiceException rangeNotSatisfiable() {
+        return new RangeNotSatisfiableException(ErrorsEnum.FILES_RANGE_NOT_SATISFIABLE)
+                .withLocale(languageContext.getCurrentLocale());
     }
 }

--- a/src/main/java/com/github/kaivu/application/usecase/impl/EntityDeviceUseCaseImpl.java
+++ b/src/main/java/com/github/kaivu/application/usecase/impl/EntityDeviceUseCaseImpl.java
@@ -11,7 +11,6 @@ import com.github.kaivu.application.port.IEntityDeviceRepository;
 import com.github.kaivu.application.service.CacheService;
 import com.github.kaivu.application.usecase.EntityDeviceUseCase;
 import com.github.kaivu.common.constant.ObservabilityConstant;
-import com.github.kaivu.common.context.AsyncObservabilityContext;
 import com.github.kaivu.common.context.LanguageContext;
 import com.github.kaivu.common.context.ObservabilityContext;
 import com.github.kaivu.common.context.TenantObservabilityContext;
@@ -51,7 +50,6 @@ public class EntityDeviceUseCaseImpl implements EntityDeviceUseCase {
     private final ObservabilityService observabilityService;
     private final ObservabilityContext observabilityContext;
     private final TenantObservabilityContext tenantContext;
-    private final AsyncObservabilityContext asyncContext;
     private final LanguageContext languageContext;
 
     @Inject
@@ -62,7 +60,6 @@ public class EntityDeviceUseCaseImpl implements EntityDeviceUseCase {
             ObservabilityService observabilityService,
             ObservabilityContext observabilityContext,
             TenantObservabilityContext tenantContext,
-            AsyncObservabilityContext asyncContext,
             LanguageContext languageContext) {
         this.config = config;
         this.entityDeviceRepository = entityDeviceRepository;
@@ -70,7 +67,6 @@ public class EntityDeviceUseCaseImpl implements EntityDeviceUseCase {
         this.observabilityService = observabilityService;
         this.observabilityContext = observabilityContext;
         this.tenantContext = tenantContext;
-        this.asyncContext = asyncContext;
         this.languageContext = languageContext;
     }
 

--- a/src/main/java/com/github/kaivu/common/constant/ErrorsKeyConstant.java
+++ b/src/main/java/com/github/kaivu/common/constant/ErrorsKeyConstant.java
@@ -10,6 +10,7 @@ public final class ErrorsKeyConstant {
     // http request defined error key constants
     public static final String INTERNAL_SERVER_ERROR = "internal_server_error";
     public static final String NOT_ACCEPTABLE = "not_acceptable";
+    public static final String RANGE_NOT_SATISFIABLE = "range_not_satisfiable";
     public static final String PERMISSION_DENIED = "permission_denied";
     public static final String UNAUTHORIZED = "unauthorized";
     public static final String INVALID_REDIRECT = "invalid_redirect";

--- a/src/main/java/com/github/kaivu/config/handler/ErrorsEnum.java
+++ b/src/main/java/com/github/kaivu/config/handler/ErrorsEnum.java
@@ -41,6 +41,9 @@ public enum ErrorsEnum implements AppErrorEnum {
     ENTITY_DEVICE_NOT_FOUND(EntitiesConstant.ENTITY_DEVICE, ErrorsKeyConstant.NOT_FOUND),
     ENTITY_DEVICE_NAME_ALREADY_EXISTS(EntitiesConstant.ENTITY_DEVICE, ErrorsKeyConstant.ALREADY_EXISTS),
 
+    // Media/File Streaming Errors
+    FILES_RANGE_NOT_SATISFIABLE(EntitiesConstant.FILES, ErrorsKeyConstant.NOT_ACCEPTABLE),
+
     // User Errors
     USER_NOT_FOUND(EntitiesConstant.USER, ErrorsKeyConstant.NOT_FOUND),
     ;

--- a/src/main/java/com/github/kaivu/config/handler/ErrorsEnum.java
+++ b/src/main/java/com/github/kaivu/config/handler/ErrorsEnum.java
@@ -42,7 +42,7 @@ public enum ErrorsEnum implements AppErrorEnum {
     ENTITY_DEVICE_NAME_ALREADY_EXISTS(EntitiesConstant.ENTITY_DEVICE, ErrorsKeyConstant.ALREADY_EXISTS),
 
     // Media/File Streaming Errors
-    FILES_RANGE_NOT_SATISFIABLE(EntitiesConstant.FILES, ErrorsKeyConstant.NOT_ACCEPTABLE),
+    FILES_RANGE_NOT_SATISFIABLE(EntitiesConstant.FILES, ErrorsKeyConstant.RANGE_NOT_SATISFIABLE),
 
     // User Errors
     USER_NOT_FOUND(EntitiesConstant.USER, ErrorsKeyConstant.NOT_FOUND),

--- a/src/main/java/com/github/kaivu/config/handler/mapper/CompositeExceptionMapper.java
+++ b/src/main/java/com/github/kaivu/config/handler/mapper/CompositeExceptionMapper.java
@@ -4,6 +4,7 @@ import com.github.kaivu.application.exception.EntityConflictException;
 import com.github.kaivu.application.exception.EntityNotFoundException;
 import com.github.kaivu.application.exception.NotAcceptableException;
 import com.github.kaivu.application.exception.PermissionDeniedException;
+import com.github.kaivu.application.exception.RangeNotSatisfiableException;
 import com.github.kaivu.application.exception.UnauthorizedException;
 import com.github.kaivu.common.constant.AppConstant;
 import com.github.kaivu.common.constant.AppHeaderConstant;
@@ -51,6 +52,7 @@ public class CompositeExceptionMapper implements ExceptionMapper<CompositeExcept
         handlers.put(EntityNotFoundException.class, this::handleNotFound);
         handlers.put(EntityConflictException.class, this::handleConflict);
         handlers.put(NotAcceptableException.class, this::handleNotAcceptable);
+        handlers.put(RangeNotSatisfiableException.class, this::handleRangeNotSatisfiable);
         handlers.put(ServiceException.class, this::handleServiceException);
         return handlers;
     }
@@ -99,6 +101,15 @@ public class CompositeExceptionMapper implements ExceptionMapper<CompositeExcept
         NotAcceptableException exception = (NotAcceptableException) ex;
         return buildErrorResponse(
                 Response.Status.NOT_ACCEPTABLE,
+                exception.getEntityName(),
+                exception.getErrorKey(),
+                exception.getMessage());
+    }
+
+    private Response handleRangeNotSatisfiable(Throwable ex) {
+        RangeNotSatisfiableException exception = (RangeNotSatisfiableException) ex;
+        return buildErrorResponse(
+                Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE,
                 exception.getEntityName(),
                 exception.getErrorKey(),
                 exception.getMessage());

--- a/src/main/java/com/github/kaivu/config/handler/mapper/ServiceExceptionMapper.java
+++ b/src/main/java/com/github/kaivu/config/handler/mapper/ServiceExceptionMapper.java
@@ -2,6 +2,7 @@ package com.github.kaivu.config.handler.mapper;
 
 import com.github.kaivu.application.exception.NotAcceptableException;
 import com.github.kaivu.application.exception.PermissionDeniedException;
+import com.github.kaivu.application.exception.RangeNotSatisfiableException;
 import com.github.kaivu.application.exception.UnauthorizedException;
 import com.github.kaivu.common.constant.AppHeaderConstant;
 import com.github.kaivu.common.constant.ObservabilityConstant;
@@ -132,6 +133,8 @@ public class ServiceExceptionMapper implements ExceptionMapper<ServiceException>
             responseBuilder = Response.status(Response.Status.FORBIDDEN);
         } else if (ex.getClass().equals(NotAcceptableException.class)) {
             responseBuilder = Response.status(Response.Status.NOT_ACCEPTABLE);
+        } else if (ex.getClass().equals(RangeNotSatisfiableException.class)) {
+            responseBuilder = Response.status(Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE);
         } else {
             responseBuilder = Response.status(Response.Status.BAD_REQUEST).entity(errorResponse);
         }

--- a/src/main/resources/META-INF/resources/index.html
+++ b/src/main/resources/META-INF/resources/index.html
@@ -496,13 +496,13 @@
             <div class="code-block">
                 <h3 style="color: var(--primary-color); margin-bottom: 20px;">Prerequisites</h3>
                 <pre><code>• Java 21 or higher
-• Gradle 7.5+ (included via wrapper)
+• Gradle 8.5+ (included via wrapper)
 • Docker (optional, for containerization)</code></pre>
 
                 <h3 style="color: var(--primary-color); margin: 30px 0 20px 0;">Clone and Run</h3>
                 <pre><code># Clone the repository
 git clone &lt;repository-url&gt;
-cd quarkus-rest
+cd quarkus-rest-boilerplate
 
 # Run in development mode with live reload
 ./gradlew quarkusDev
@@ -518,7 +518,7 @@ cd quarkus-rest
 java -jar build/quarkus-app/quarkus-run.jar
 
 # Build native executable (requires GraalVM)
-./gradlew build -Dquarkus.package.type=native</code></pre>
+./gradlew build -Dquarkus.package.native=true</code></pre>
 
                 <h3 style="color: var(--primary-color); margin: 30px 0 20px 0;">Docker Support</h3>
                 <pre><code># One-Command Docker Setup (Recommended)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,7 +101,7 @@ quarkus:
 
   native:
     additional-build-args:
-      - ${QUARKUS_NATIVE_ADDITIONAL_BUILD_ARGS:--initialize-at-run-time=com.github.kaivu.config.ApplicationConfiguration}
+      - ${QUARKUS_NATIVE_ADDITIONAL_BUILD_ARGS:--initialize-at-run-time=com.github.kaivu.config.AppConfiguration}
     container-build: ${QUARKUS_NATIVE_CONTAINER_BUILD:false}
 
 minio:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,10 +79,10 @@ quarkus:
     info-title: Demo Service
     info-version: 1.0.0
     info-description: Just an example service
-    info-terms-of-service: Your terms here
+    info-terms-of-service: https://github.com/khoavu882/quarkus-rest-boilerplate
     info-contact-email: khoavu882@gmail.com
     info-contact-name: Vu Dang Khoa
-    info-contact-url: http://aomacannada.can
+    info-contact-url: https://github.com/khoavu882/quarkus-rest-boilerplate
     info-license-name: Apache 2.0
     info-license-url: https://www.apache.org/licenses/LICENSE-2.0.html
     security-scheme: jwt

--- a/src/main/resources/i18n/error_messages.properties
+++ b/src/main/resources/i18n/error_messages.properties
@@ -20,4 +20,6 @@ demo_rest.conflict=The remote demo client reported a conflicting request.
 entity_device.not_found=Device %s not found.
 entity_device.already_exists=Device %s already exists.
 
+files.not_acceptable=Requested range is not satisfiable for this file.
+
 user.not_found=Email %s not found.

--- a/src/main/resources/i18n/error_messages.properties
+++ b/src/main/resources/i18n/error_messages.properties
@@ -20,6 +20,6 @@ demo_rest.conflict=The remote demo client reported a conflicting request.
 entity_device.not_found=Device %s not found.
 entity_device.already_exists=Device %s already exists.
 
-files.not_acceptable=Requested range is not satisfiable for this file.
+files.range_not_satisfiable=Requested range is not satisfiable for this file.
 
 user.not_found=Email %s not found.

--- a/src/main/resources/i18n/error_messages.properties
+++ b/src/main/resources/i18n/error_messages.properties
@@ -12,6 +12,10 @@ auth.permission_denied=You do not have permission to access this resource.
 auth.invalid_redirect=Invalid redirect target.
 
 demo_rest.client_bad_request='%s' client timeout or response error. Http Code: %s.
+demo_rest.internal_server_error=The remote demo client returned an internal server error.
+demo_rest.permission_denied=The remote demo client denied permission for this request.
+demo_rest.unauthorized=The remote demo client rejected this request as unauthorized.
+demo_rest.conflict=The remote demo client reported a conflicting request.
 
 entity_device.not_found=Device %s not found.
 entity_device.already_exists=Device %s already exists.

--- a/src/main/resources/i18n/error_messages_en.properties
+++ b/src/main/resources/i18n/error_messages_en.properties
@@ -20,4 +20,6 @@ demo_rest.conflict=The remote demo client reported a conflicting request.
 entity_device.not_found=Device %s not found.
 entity_device.already_exists=Device %s already exists.
 
+files.not_acceptable=Requested range is not satisfiable for this file.
+
 user.not_found=Email %s not found.

--- a/src/main/resources/i18n/error_messages_en.properties
+++ b/src/main/resources/i18n/error_messages_en.properties
@@ -20,6 +20,6 @@ demo_rest.conflict=The remote demo client reported a conflicting request.
 entity_device.not_found=Device %s not found.
 entity_device.already_exists=Device %s already exists.
 
-files.not_acceptable=Requested range is not satisfiable for this file.
+files.range_not_satisfiable=Requested range is not satisfiable for this file.
 
 user.not_found=Email %s not found.

--- a/src/main/resources/i18n/error_messages_en.properties
+++ b/src/main/resources/i18n/error_messages_en.properties
@@ -12,6 +12,10 @@ auth.permission_denied=You do not have permission to access this resource.
 auth.invalid_redirect=Invalid redirect target.
 
 demo_rest.client_bad_request='%s' client timeout or response error. Http Code: %s.
+demo_rest.internal_server_error=The remote demo client returned an internal server error.
+demo_rest.permission_denied=The remote demo client denied permission for this request.
+demo_rest.unauthorized=The remote demo client rejected this request as unauthorized.
+demo_rest.conflict=The remote demo client reported a conflicting request.
 
 entity_device.not_found=Device %s not found.
 entity_device.already_exists=Device %s already exists.

--- a/src/main/resources/i18n/error_messages_vi.properties
+++ b/src/main/resources/i18n/error_messages_vi.properties
@@ -12,6 +12,10 @@ auth.permission_denied=Bạn không có quyền truy cập tài nguyên này.
 auth.invalid_redirect=Địa chỉ chuyển hướng không hợp lệ.
 
 demo_rest.client_bad_request='%s' client timeout hoặc lỗi phản hồi. Http Code: %s.
+demo_rest.internal_server_error=Máy khách demo từ xa gặp lỗi máy chủ nội bộ.
+demo_rest.permission_denied=Máy khách demo từ xa từ chối quyền truy cập cho yêu cầu này.
+demo_rest.unauthorized=Máy khách demo từ xa từ chối yêu cầu này do chưa xác thực.
+demo_rest.conflict=Máy khách demo từ xa báo cáo yêu cầu bị xung đột.
 
 entity_device.not_found=Thiết bị %s không tồn tại.
 entity_device.already_exists=Thiết bị %s đã tồn tại.

--- a/src/main/resources/i18n/error_messages_vi.properties
+++ b/src/main/resources/i18n/error_messages_vi.properties
@@ -20,6 +20,6 @@ demo_rest.conflict=Máy khách demo từ xa báo cáo yêu cầu bị xung độ
 entity_device.not_found=Thiết bị %s không tồn tại.
 entity_device.already_exists=Thiết bị %s đã tồn tại.
 
-files.not_acceptable=Phạm vi yêu cầu không hợp lệ đối với tệp này.
+files.range_not_satisfiable=Phạm vi yêu cầu không hợp lệ đối với tệp này.
 
 user.not_found=Người dùng %s không tồn tại.

--- a/src/main/resources/i18n/error_messages_vi.properties
+++ b/src/main/resources/i18n/error_messages_vi.properties
@@ -20,4 +20,6 @@ demo_rest.conflict=Máy khách demo từ xa báo cáo yêu cầu bị xung độ
 entity_device.not_found=Thiết bị %s không tồn tại.
 entity_device.already_exists=Thiết bị %s đã tồn tại.
 
+files.not_acceptable=Phạm vi yêu cầu không hợp lệ đối với tệp này.
+
 user.not_found=Người dùng %s không tồn tại.


### PR DESCRIPTION
## Summary
Release v1.1.1 — Phase 0 of `agent-docs/refactoring-plan_2026-07-08.md` (merged to `develop` via #47),
cut for release now that v1.1.0 is out. Bug fixes and isolated hygiene only; no new features.

- **Docker/native-build config drift**: `docker-compose.yml`/`docker-compose-native.yml` set env vars
  the app never reads (`DEMO_HOST`, `MINIO_ENDPOINT`, `ENABLE_QUARKUS_MANAGEMENT`) — renamed to what it
  actually binds (`QUARKUS_DATASOURCE_*`, `MINIO_URL` pointed at MinIO's container-internal port 9000,
  `QUARKUS_MANAGEMENT_ENABLED`). Fixed a native-build arg referencing a renamed/deleted class and a
  hardcoded versioned artifact path in `Dockerfile.native`.
- **i18n gaps**: added the 4 missing `ClientErrorsEnum` bundle keys (en/vi/default).
- **Stale docs**: OpenAPI placeholder values, `index.html`'s Gradle version/native-flag/clone-dir
  references corrected.
- **Code correctness**: `EntityDevicesResource` switched from field to constructor injection, matching
  every other class's convention. `MediaStreamingService.parseRangeHeader()` no longer throws an
  unmapped `NumberFormatException` or silently mis-serves out-of-bounds/suffix-range `Range` headers —
  added a dedicated `RangeNotSatisfiableException` (416) wired into both exception mappers, matching
  the endpoint's own OpenAPI contract. Removed an unused constructor parameter from
  `EntityDeviceUseCaseImpl`.

Full trail: PR #47, `agent-docs/specs/refactoring-plan-phase0/`.

## Test plan
- [x] `./gradlew spotlessCheck compileJava` passes on this branch
- [x] Already reviewed via `/do-review` on #47 (traceability pass against spec/tasks, one round of
      review-driven fixes applied)
- [ ] Manual smoke test against a running Docker stack — recommended before tagging if you want live
      verification beyond the static checks already done

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>